### PR TITLE
chore: add graphql env vars

### DIFF
--- a/charts/tce-all-in-one/Chart.yaml
+++ b/charts/tce-all-in-one/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tce-all-in-one/templates/01-tce-deployments.yaml
+++ b/charts/tce-all-in-one/templates/01-tce-deployments.yaml
@@ -89,6 +89,8 @@ spec:
               value: "{{ $.Values.env.TCE_DB_PATH }}"
             - name: TCE_API_ADDR
               value: "{{ $.Values.env.TCE_API_ADDR }}"
+            - name: TCE_GRAPHQL_API_ADDR
+              value: "{{ $.Values.env.TCE_GRAPHQL_API_ADDR }}"
             - name: TOPOS_OTLP_SERVICE_NAME
               value: "{{ $.Values.env.TOPOS_OTLP_SERVICE_NAME }}"
             - name: TOPOS_OTLP_AGENT

--- a/charts/tce-all-in-one/values.yaml
+++ b/charts/tce-all-in-one/values.yaml
@@ -34,6 +34,7 @@ env:
   RUST_LOG: warn,topos=warn
   TCE_DB_PATH: /tmp/default-db
   TCE_API_ADDR: 0.0.0.0:1340
+  TCE_GRAPHQL_API_ADDR: 0.0.0.0:4000
   TOPOS_OTLP_AGENT: tce-node
   TOPOS_OTLP_SERVICE_NAME: https://telemetry.nowhere.com
   TCE_ECHO_SAMPLE_SIZE: "6"


### PR DESCRIPTION
# Description

This PR adds the recently introduced `TCE_GRAPHQL_API_ADDR` to the TCE deployment object, which will enable users to change its default values.

As an example, [Minikube doesn't support ipv6 at the moment](https://minikube.sigs.k8s.io/docs/faq/#do-i-need-to-install-kubectl-locally). Using `TCE_GRAPHQL_API_ADDR` env to change the default address/port will fix errors such as:
```
2023-06-20T11:53:34.543153Z  WARN topos_p2p::runtime: Network bootstrap finished                                                                                           
thread 'main' panicked at 'error binding to [::1]:4000: error creating server listener: Cannot assign requested address (os error 99)', /usr/local/cargo/registry/src/githu
b.com-1ecc6299db9ec823/hyper-0.14.26/src/server/server.rs:79:13 
```


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
