### PR TITLE
feat: add cors ingress annotations for faucet

### DIFF
--- a/charts/faucet/Chart.yaml
+++ b/charts/faucet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faucet/templates/02-faucet-ingress.yaml
+++ b/charts/faucet/templates/02-faucet-ingress.yaml
@@ -4,6 +4,8 @@ metadata:
   name: faucet
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For"
     cert-manager.io/cluster-issuer: "letsencrypt-{{ .Values.acme.environment }}"
 spec:
   tls:


### PR DESCRIPTION
# Description

This PR adds CORS kubernetes annotations to the Faucet's Ingress object to allow CORS and use the `x-forwarded-for` header to pass the client actual IP address (needed for the Faucet's rate limiting security feature).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
