### PR TITLE
chore: use json format by default

### DIFF
--- a/charts/tce-all-in-one/Chart.yaml
+++ b/charts/tce-all-in-one/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tce-all-in-one/templates/01-tce-statefulset.yaml
+++ b/charts/tce-all-in-one/templates/01-tce-statefulset.yaml
@@ -72,6 +72,8 @@ spec:
               value: "{{ $.Values.env.TOPOS_RUN_ID }}"
             - name: TOPOS_RUN_NUMBER
               value: "{{ $.Values.env.TOPOS_RUN_NUMBER }}"
+            - name: TOPOS_LOG_FORMAT
+              value: "{{ $.Values.env.TOPOS_LOG_FORMAT }}"
             - name: HOSTNAME
               valueFrom:
                 fieldRef:

--- a/charts/tce-all-in-one/values.yaml
+++ b/charts/tce-all-in-one/values.yaml
@@ -27,5 +27,6 @@ image:
 env:
   TOPOS_HOME: /data
   RUST_LOG: info,topos=debug,topos::edge=error
+  TOPOS_LOG_FORMAT: json
   TOPOS_RUN_ID:
   TOPOS_RUN_NUMBER:


### PR DESCRIPTION
# Description

Export `TOPOS_LOG_FORMAT` and set it to `json` by default.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
